### PR TITLE
Quote variables to prevent splitting

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-export URUHA_WORK_DIRECTORY=$(pwd)
+export URUHA_WORK_DIRECTORY=$PWD
 
-SUDO=''
+SUDO=""
 if [ "$EUID" != 0 ]; then
-    SUDO='sudo'
+    SUDO="sudo"
 fi
 
 URUHA_MOUNT() {
@@ -19,14 +19,14 @@ URUHA_MOUNT() {
 
     for name in tmp proc sys dev dev/pts etc/resolv.conf
     do
-        $SUDO mount --bind /$name $URUHA_WORK_DIRECTORY/rootfs/$name
+        $SUDO mount --bind /$name "$URUHA_WORK_DIRECTORY/rootfs/$name"
     done
 }
 
 URUHA_UMOUNT() {
     for name in etc/resolv.conf dev/pts dev sys proc tmp
     do
-        $SUDO umount $URUHA_WORK_DIRECTORY/rootfs/$name
+        $SUDO umount "$URUHA_WORK_DIRECTORY/rootfs/$name"
     done
 
     rm /tmp/uruha.lock

--- a/init_rootfs.sh
+++ b/init_rootfs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export URUHA_WORK_DIRECTORY=$(pwd)
+export URUHA_WORK_DIRECTORY=$PWD
 
 if [ -d "$URUHA_WORK_DIRECTORY/rootfs" ]; then
     echo "rootfs already exists, exits for preventing from unexpected initiating."
@@ -16,32 +16,32 @@ else
     exit 1
 fi
 
-SUDO=''
+SUDO=""
 if [ "$EUID" != 0 ]; then
-    SUDO='sudo'
+    SUDO="sudo"
 fi
 
-$SUDO wget -O $URUHA_WORK_DIRECTORY/rootfs.tar.gz http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.3-base-amd64.tar.gz
+$SUDO wget -O "$URUHA_WORK_DIRECTORY/rootfs.tar.gz" http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.3-base-amd64.tar.gz
 
-$SUDO mkdir $URUHA_WORK_DIRECTORY/rootfs
+$SUDO mkdir "$URUHA_WORK_DIRECTORY/rootfs"
 
-$SUDO tar -zxvf $URUHA_WORK_DIRECTORY/rootfs.tar.gz -C $URUHA_WORK_DIRECTORY/rootfs
-$SUDO rm $URUHA_WORK_DIRECTORY/rootfs.tar.gz
+$SUDO tar -zxvf "$URUHA_WORK_DIRECTORY/rootfs.tar.gz" -C "$URUHA_WORK_DIRECTORY/rootfs"
+$SUDO rm "$URUHA_WORK_DIRECTORY/rootfs.tar.gz"
 
-$SUDO cp $URUHA_WORK_DIRECTORY/.rootfs_setup.sh $URUHA_WORK_DIRECTORY/rootfs/setup.sh
-$SUDO chmod +x $URUHA_WORK_DIRECTORY/rootfs/setup.sh
+$SUDO cp "$URUHA_WORK_DIRECTORY/.rootfs_setup.sh" "$URUHA_WORK_DIRECTORY/rootfs/setup.sh"
+$SUDO chmod +x "$URUHA_WORK_DIRECTORY/rootfs/setup.sh"
 
 for name in tmp proc sys dev dev/pts etc/resolv.conf
 do
-    $SUDO mount --bind /$name $URUHA_WORK_DIRECTORY/rootfs/$name
+    $SUDO mount --bind /$name "$URUHA_WORK_DIRECTORY/rootfs/$name"
 done
 
-$SUDO chroot $URUHA_WORK_DIRECTORY/rootfs /bin/bash /setup.sh
+$SUDO chroot "$URUHA_WORK_DIRECTORY/rootfs" /bin/bash /setup.sh
 
 for name in etc/resolv.conf dev/pts dev sys proc tmp
 do
-    $SUDO umount $URUHA_WORK_DIRECTORY/rootfs/$name
+    $SUDO umount "$URUHA_WORK_DIRECTORY/rootfs/$name"
 done
 
-$SUDO rm $URUHA_WORK_DIRECTORY/rootfs/setup.sh
+$SUDO rm "$URUHA_WORK_DIRECTORY/rootfs/setup.sh"
 rm /tmp/uruha.lock


### PR DESCRIPTION
`URUHA_WORK_DIRECTORY` is set to the user's current working directory. It's entirely possible that this directory contains whitespace. Therefore, all usages of this variable should be quoted to prevent word splitting. For example, in `activate.sh`, there is the line `$SUDO umount $URUHA_WORK_DIRECTORY/rootfs/$name`. If I run this from directory `/home/florine/cool directory/`, then without quotes this line would be executed as `sudo umount /home/florine/cool home directory/rootfs/dev`. In other words, you'd be telling `umount` to unmount `home`!

I also replaced `$(pwd)` with `$PWD` because (1) why not and (2) you can't accidentally suppress an error exit code if you don't use a subshell.

And I replaced the quotes when defining `SUDO` from `'` to `"`, but that's purely for consistency with the other quotes I've added.

(The reason no quotes are added around usages of `SUDO` is because its value is always either the empty string or `sudo`. No word splitting can occur here.)